### PR TITLE
BF: Fix ioHub finding eyetracker

### DIFF
--- a/psychopy_eyetracker_tobii/tobii/default_eyetracker.yaml
+++ b/psychopy_eyetracker_tobii/tobii/default_eyetracker.yaml
@@ -1,4 +1,4 @@
-eyetracker.hw.tobii.EyeTracker:
+eyetracker.tobii.EyeTracker:
     # Indicates if the device should actually be loaded at experiment runtime.
     enable: True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,11 +49,8 @@ tests = [
 [tool.setuptools.packages.find]
 where = ["", "psychopy_eyetracker_tobii",]
 
-[project.entry-points."psychopy.iohub.devices"]
-EyeTracker = "psychopy_eyetracker_tobii.tobii.eyetracker:EyeTracker"
-
 [project.entry-points."psychopy.iohub.devices.eyetracker"]
-EyeTracker = "psychopy_eyetracker_tobii.tobii.eyetracker:EyeTracker"
+tobii = "psychopy_eyetracker_tobii.tobii"
 
 [tool.setuptools.package-data]
 "*" = ["*.yaml"]


### PR DESCRIPTION
In conjunction with [this PR](https://github.com/psychopy/psychopy/pull/6574) to PsychoPy, these changes allow ioHub to find the eyetracker class and its associated YAML via its entry point into PsychoPy.